### PR TITLE
Remove optparse

### DIFF
--- a/python-lib/prologin/mdb/management/commands/addmachine.py
+++ b/python-lib/prologin/mdb/management/commands/addmachine.py
@@ -19,21 +19,20 @@ import time
 
 from django.core.management.base import BaseCommand, CommandError
 from prologin.mdb.models import Machine
-from optparse import make_option
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--hostname', help='Machine name'),
-        make_option('--aliases', help='DNS aliases (comma separated)'),
-        make_option('--ip', help='Machine IP address'),
-        make_option('--mac', help='Machine MAC address'),
-        make_option('--rfs', help='RFS used by the machine'),
-        make_option('--hfs', help='HFS used by the machine'),
-        make_option('--mtype',
-                    help='Machine type (user/orga/cluster/service)'),
-        make_option('--room',
-                    help='Machine location (pasteur/alt/cluster/other)'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--hostname', help='machine_name')
+        parser.add_argument('--aliases', help='DNS aliases (comma separated)')
+        parser.add_argument('--ip', help='Machine IP address')
+        parser.add_argument('--mac', help='Machine MAC address')
+        parser.add_argument('--rfs', help='RFS used by the machine')
+        parser.add_argument('--hfs', help='HFS used by the machine')
+        parser.add_argument('--mtype',
+                    help='Machine type (user/orga/cluster/service)')
+        parser.add_argument('--room',
+                    help='Machine location (pasteur/alt/cluster/other)')
 
     def get_opt(self, options, name):
         if name not in options:

--- a/python-lib/prologin/mdb/management/commands/ansible.py
+++ b/python-lib/prologin/mdb/management/commands/ansible.py
@@ -23,7 +23,6 @@ References:
 """
 
 import json
-from optparse import make_option
 from django.core.management.base import BaseCommand
 
 from prologin.mdb.models import Machine
@@ -31,9 +30,10 @@ from prologin.mdb.models import Machine
 
 class Command(BaseCommand):
     help = 'Ansible dynamic inventory from mdb'
-    option_list = BaseCommand.option_list + (
-        make_option('--list', action='store_true', help='display list of hosts'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--list', action='store_true',
+                help='display list of hosts')
 
     def handle(self, *args, **kwargs):
         ret = { k: { 'hosts': [],

--- a/python-lib/prologin/mdb/management/commands/pssh.py
+++ b/python-lib/prologin/mdb/management/commands/pssh.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Prologin-SADM.  If not, see <http://www.gnu.org/licenses/>.
 
-from optparse import make_option
 import subprocess
 import sys
 import time
@@ -24,18 +23,18 @@ from django.core.management.base import BaseCommand, CommandError
 from prologin.mdb.models import Machine
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--hostname', help='Machine name'),
-        make_option('--ip', help='Machine IP address'),
-        make_option('--mac', help='Machine MAC address'),
-        make_option('--rfs', help='RFS used by the machines'),
-        make_option('--hfs', help='HFS used by the machines'),
-        make_option('--user', help='SSH as this user (default: root)'),
-        make_option('--mtype',
-                    help='Machines type (user/orga/cluster/service)'),
-        make_option('--room',
-                    help='Machines location (pasteur/alt/cluster/other'),
-    )
+
+    def add_aguments(self, parser):
+        parser.add_argument('--hostname', help='Machine name')
+        parser.add_argument('--ip', help='Machine IP address')
+        parser.add_argument('--mac', help='Machine MAC address')
+        parser.add_argument('--rfs', help='RFS used by the machines')
+        parser.add_argument('--hfs', help='HFS used by the machines')
+        parser.add_argument('--user', help='SSH as this user (default: root)')
+        parser.add_argument('--mtype',
+                    help='Machines type (user/orga/cluster/service)')
+        parser.add_argument('--room',
+                    help='Machines location (pasteur/alt/cluster/other')
 
     def handle(self, *args, **options):
         user = options['user'] or 'root'

--- a/python-lib/prologin/udb/management/commands/batchimport.py
+++ b/python-lib/prologin/udb/management/commands/batchimport.py
@@ -21,7 +21,6 @@ import subprocess
 import unicodedata
 
 from django.core.management import BaseCommand, CommandError
-from optparse import make_option
 from prologin.udb.models import User
 
 
@@ -88,13 +87,18 @@ def create_users(names, options):
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--file', help='File with "first name\\tlast name" lines'),
-        make_option('--type', default='user', help='User type (user/orga/root)'),
-        make_option('--pwdlen', type='int', default=8, help='Password length'),
-        make_option('--logins', action='store_true', default=False, help='File contains logins, not real names'),
-        make_option('--passwords', action='store_true', default=False, help='File contains passwords after a colon'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--file',
+                            help='File with "first name\\tlast name" lines')
+        parser.add_argument('--type', default='user',
+                            help='User type (user/orga/root)')
+        parser.add_argument('--pwdlen', type='int', default=8,
+                            help='Password length')
+        parser.add_argument('--logins', action='store_true', default=False,
+                            help='File contains logins, not real names')
+        parser.add_argument('--passwords', action='store_true', default=False,
+                            help='File contains passwords after a colon')
 
     def handle(self, *args, **options):
         if options['file'] is None:

--- a/python-lib/prologin/udb/management/commands/pwdsheetdata.py
+++ b/python-lib/prologin/udb/management/commands/pwdsheetdata.py
@@ -18,14 +18,14 @@
 # Exports the data required to print password sheets for users.
 
 from django.core.management import BaseCommand, CommandError
-from optparse import make_option
 from prologin.udb.models import User
 
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--type', default='user', help='User type (user/orga/root)'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('--type', default='user',
+                            help='User type (user/orga/root)')
 
     def handle(self, *args, **options):
         users = User.objects.filter(group=options['type'])


### PR DESCRIPTION
As BaseCommand.option_list has been deprecated since Django 1.8 and has now been dropped, this pull request replaces all calls to optparse in mdb and udb and usages of option_list with the add_arguments method and calls to parser.add_argument.