### PR TITLE
Use a mirror list instead of a single mirror during archlinux bootstrap

### DIFF
--- a/install_scripts/bootstrap_arch_linux.sh
+++ b/install_scripts/bootstrap_arch_linux.sh
@@ -12,6 +12,8 @@ SADM_TIMEZONE='Europe/Paris'
 ARCH_MIRROR=http://archlinux.mirrors.ovh.net/archlinux
 # Release used for bootstraping from a non-Arch Linux system
 ARCH_RELEASE_DATE=2017.04.01
+# Mirror list to use in case we don't have access to pacstrap
+MIRRORLIST_URL="https://www.archlinux.org/mirrorlist/?country=FR&protocol=https&ip_version=4&ip_version=6&use_mirror_status=on"
 
 # Usage
 if [ $# -ne 3 ]; then
@@ -55,15 +57,12 @@ fi
 echo_status "Installing base Arch Linux"
 if test -e /etc/arch-release; then
   pacstrap -c -d "$root_dir" base
-  cp /etc/pacman.d/mirrorlist "$root_dir/etc/pacman.d/mirrorlist"
 else
   (
     cd /tmp
     wget --continue $ARCH_MIRROR/iso/$ARCH_RELEASE_DATE/archlinux-bootstrap-$ARCH_RELEASE_DATE-x86_64.tar.gz
     tar --strip-components=1 --directory="$root_dir" -xf archlinux-bootstrap-$ARCH_RELEASE_DATE-x86_64.tar.gz
-    cat >"$root_dir/etc/pacman.d/mirrorlist" <<EOF
-Server = $ARCH_MIRROR/\$repo/os/\$arch
-EOF
+    curl "$MIRRORLIST_URL" | sed 's/^#//' > "$rootdir"/etc/pacman.d/mirrorlist
   )
 
   systemd-nspawn --quiet --directory "$root_dir" --bind /dev/urandom:/dev/random /usr/bin/pacman-key --init

--- a/install_scripts/bootstrap_arch_linux.sh
+++ b/install_scripts/bootstrap_arch_linux.sh
@@ -55,21 +55,20 @@ fi
 echo_status "Installing base Arch Linux"
 if test -e /etc/arch-release; then
   pacstrap -c -d "$root_dir" base
+  cp /etc/pacman.d/mirrorlist "$root_dir/etc/pacman.d/mirrorlist"
 else
   (
     cd /tmp
     wget --continue $ARCH_MIRROR/iso/$ARCH_RELEASE_DATE/archlinux-bootstrap-$ARCH_RELEASE_DATE-x86_64.tar.gz
     tar --strip-components=1 --directory="$root_dir" -xf archlinux-bootstrap-$ARCH_RELEASE_DATE-x86_64.tar.gz
+    cat >"$root_dir/etc/pacman.d/mirrorlist" <<EOF
+Server = $ARCH_MIRROR/\$repo/os/\$arch
+EOF
   )
 
   systemd-nspawn --quiet --directory "$root_dir" --bind /dev/urandom:/dev/random /usr/bin/pacman-key --init
   systemd-nspawn --quiet --directory "$root_dir" /usr/bin/pacman-key --populate archlinux
 fi
-
-echo_status "Configure Arch Linux repository"
-cat >"$root_dir/etc/pacman.d/mirrorlist" <<EOF
-Server = $ARCH_MIRROR/\$repo/os/\$arch
-EOF
 
 systemd-nspawn -D "$root_dir" /usr/bin/pacman -Syu --needed --noconfirm base vim openssh rxvt-unicode-terminfo
 

--- a/install_scripts/bootstrap_from_install_medium.sh
+++ b/install_scripts/bootstrap_from_install_medium.sh
@@ -4,6 +4,7 @@
 # It does a standalone clone and setup of sadm from the main git repository. If
 # you are developping on SADM, directly use install_scripts/setup_sadm.sh
 
+MIRRORLIST_URL="https://www.archlinux.org/mirrorlist/?country=FR&protocol=https&ip_version=4&ip_version=6&use_mirror_status=on"
 REPO_URL=https://github.com/prologin/sadm
 BRANCH=master
 
@@ -13,6 +14,9 @@ if mount | grep --quiet archiso; then
   echo '[+] Increasing the size of /run/archiso/cowspace'
   mount -o remount,size=2G /run/archiso/cowspace
 fi
+
+echo '[+] Retreiving mirror list'
+curl "$MIRRORLIST_URL" | sed 's/^#//' > /etc/pacman.d/mirrorlist
 
 echo '[+] Installing dependencies'
 pacman -Sy --needed --noconfirm git


### PR DESCRIPTION
This allowed me to setup SADM with my bad internet connection.

Without this, it would often fail to download a package, and since there was only a single mirror it would stop the setup.