### PR TITLE
Add rust compiler to contestants' environment

### DIFF
--- a/rfs/package_list_extra
+++ b/rfs/package_list_extra
@@ -111,6 +111,8 @@ List of packages for contestants' environment
 * mono
 * php
 * ghc
+* rust
+* rust-docs
 
 
 # IRC clients


### PR DESCRIPTION
It seems there is an interest for using this language during the contest: https://prologin.org/forum/serveur-finale-site-web-4/binding-stechec2-pour-rust-1014/

I also added standard library API docs, but this could be removed.
The rust package builder `cargo` could also be added to this list.