### PR TITLE
rhfs: networkd: add CriticalConnection=yes

### DIFF
--- a/etc/systemd/network/10-rhfs.network
+++ b/etc/systemd/network/10-rhfs.network
@@ -6,3 +6,6 @@ DHCP=yes
 
 # Gather LLDP packets
 LLDP=yes
+
+[DHCP]
+CriticalConnection=yes


### PR DESCRIPTION
This prevents everything from crashing when the dhcp is down