### PR TITLE
dhcpd.conf: give long leases, except for aliens

### DIFF
--- a/etc/dhcpd.conf
+++ b/etc/dhcpd.conf
@@ -14,8 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Prologin-SADM.  If not, see <http://www.gnu.org/licenses/>.
 
-default-lease-time 30;
-max-lease-time 30;
+default-lease-time 14400;
+max-lease-time 14400;
 
 authoritative;
 
@@ -89,6 +89,9 @@ shared-network prolo-lan {
     # Alien subnet. Everyone who does not have a static allocation will be
     # put in this subnet.
     subnet 192.168.250.0 netmask 255.255.255.0 {
+        default-lease-time 30;
+        max-lease-time 30;
+
         range 192.168.250.1 192.168.250.200;
 
         option ipxe.scriptlet "alien";


### PR DESCRIPTION
The purpose is to try to mitigate the lease loss that is regularly experienced because of some instable network setup. We never reassign IPs, and when if we do, we can use the mdb ip pool allocator, which never reuses IPs anyway.