### PR TITLE
install_scripts: bootstrap_arch_linux: initialize machine ID

### DIFF
--- a/install_scripts/bootstrap_arch_linux.sh
+++ b/install_scripts/bootstrap_arch_linux.sh
@@ -56,6 +56,10 @@ if [ ! -r $root_password_file ]; then
     exit 1
 fi
 
+# Initialize /etc/machine-id at something different than the machine-id of the host
+echo_status "Initializing machine-id"
+systemd-machine-id-setup --root="$root_dir" --print
+
 # The actual Arch Linux setup starts here
 echo_status "Installing base Arch Linux"
 if test -e /etc/arch-release; then


### PR DESCRIPTION
Using `systemd-nspawn` was throwing errors like this:
```
Host and machine ids are equal (23f82fcbdecb4ab4965ed34533f3cbd4): refusing to link journals
```

Fixed by using [systemd-machine-id-setup](https://www.freedesktop.org/software/systemd/man/systemd-machine-id-setup.html) in order to set the machine-id of the machine being installed to something different from the host