### PR TITLE
Add some packages to IgnorePkg

### DIFF
--- a/install_scripts/setup_sadm.sh
+++ b/install_scripts/setup_sadm.sh
@@ -27,9 +27,9 @@ pacman -Sy
 # Packages we expect to have installed on all the systems
 echo '[+] Installing packages from the Arch Linux repositories'
 pacman -S --needed --noconfirm base-devel git python python2 python-pip \
-    python-virtualenv libyaml libxslt postgresql-libs sqlite postgresql-libs \
-    pwgen dnsutils rsync tcpdump strace wget ethtool tree mtr iperf atop htop \
-    iotop iftop nethogs jq tmux
+    python-virtualenv libyaml libxslt postgresql-libs sqlite pwgen dnsutils \
+    rsync tcpdump strace wget ethtool tree mtr iperf atop htop iotop iftop \
+    nethogs jq tmux
 
 echo '[+] Installing packages from the Prologin Arch Linux repository'
 pacman -S --needed --noconfirm bash-eternal-history

--- a/install_scripts/setup_sadm.sh
+++ b/install_scripts/setup_sadm.sh
@@ -12,6 +12,10 @@ Server = https://repo.prologin.org/
 EOF
 fi
 
+sed -i 's/^[#]IgnorePkg.*$/# Ignoring all of the following packages\
+IgnorePkg = linux postgresql\*\
+/' /etc/pacman.conf
+
 curl https://repo.prologin.org/prologin.pub > /tmp/prologin.pub
 pacman-key --add /tmp/prologin.pub
 pacman-key --lsign-key prologin


### PR DESCRIPTION
In `install_scripts/setup.sadm.sh`, changing the lines `#IgnorePkg = ` and `#IgnoreGroup =` in `/etc/pacman.conf` to prevent packages from being upgraded during the final.
Closes #120 