### PR TITLE
Add bspwm to the contestants package list

### DIFF
--- a/rfs/package_list_extra
+++ b/rfs/package_list_extra
@@ -56,6 +56,7 @@ List of packages for contestants' environment
 * gnome
 * xfce4
 (aur)* dwm
+* bspwm
 
 
 # Browsers

--- a/rfs/package_list_extra
+++ b/rfs/package_list_extra
@@ -95,6 +95,7 @@ List of packages for contestants' environment
 * xcape
 * dmenu
 * synergy
+* sxhkd
 
 
 # Compilers & interpreters


### PR DESCRIPTION
I'd like to suggest adding [bspwm](https://github.com/baskerville/bspwm) to the list of available graphical environments for the final (and, of course, [sxhkd](https://github.com/baskerville/sxhkd) for keybindings).