### PR TITLE
Add Visual Studio Code to the package list

### DIFF
--- a/rfs/package_list_extra
+++ b/rfs/package_list_extra
@@ -40,6 +40,7 @@ List of packages for contestants' environment
 (aur)* monodevelop-stable
 * netbeans
 * atom
+* code
 
 (aur)* codelite
 * pycharm-community-edition


### PR DESCRIPTION
I would like [Visual Studio Code](https://code.visualstudio.com/) to be added to the package list as it is a very popular code editor.

Its open source build, which is the one I want to add to the package list with this pull request, is available in the Community repository of Arch Linux.