### PR TITLE
udbsync: update both nfsroot_staging and nfsroot_ro in udbsync.passwd

### DIFF
--- a/etc/systemd/system/udbsync_passwd_nfsroot.service
+++ b/etc/systemd/system/udbsync_passwd_nfsroot.service
@@ -1,11 +1,18 @@
 [Unit]
-Description=/etc/{passwd,shadow,group} synchronization daemon for nfsroot
+Description=/etc/{passwd,shadow,group} synchronization daemon for nfsroot_staging and nfsroot_ro
 After=network-online.target
 
 [Service]
 Type=simple
 User=root
-ExecStart=/opt/prologin/venv/bin/python -m prologin.udbsync_clients.passwd /export/nfsroot_ro
+# Update nfsroot_staging so the latest version is copied when admins use the
+# commit_staging.sh script. But also copy to nfsroot_ro so changes are synced
+# to machines immediately.
+# This could be racy with package installation in nfsroot_staging, but it's
+# rather unlikely.
+ExecStart=/opt/prologin/venv/bin/python -m prologin.udbsync_clients.passwd \
+    --root /export/nfsroot_staging \
+    --exec-after '/usr/bin/cp --preserve=all /export/nfsroot_staging/etc/passwd /export/nfsroot_staging/etc/shadow /export/nfsroot_staging/etc/group /export/nfsroot_ro/etc'
 Restart=always
 RestartSec=2
 

--- a/rfs/commit_staging.sh
+++ b/rfs/commit_staging.sh
@@ -21,7 +21,6 @@ for serv in "$@"; do
     echo "## restarting metadata services on $serv"
     ssh -T root@"$serv" <<EOF
 systemctl restart rootssh-copy
-systemctl restart udbsync_passwd_nfsroot
 EOF
 
 done


### PR DESCRIPTION
Fixes #169.

Tested:

```console
$ machinectl shell myrhfs0
$ diff -u /export/nfsroot_{staging,ro}/etc/group
  ( empty )

$ systemd-nspawn -D /export/nfsroot_staging
  $ pacman -S minidlna
  ...
  Creating user minidlna (minidlna server) with uid 971 and gid 971.

$ diff -u /export/nfsroot_{staging,ro}/etc/group
--- /export/nfsroot_staging/etc/group   2020-03-15 21:36:38.539844642 +0100
+++ /export/nfsroot_ro/etc/group        2020-03-15 21:34:10.167058855 +0100
@@ -76,2 +76,1 @@
-minidlna:x:971:

$ systemctl restart udbsync_passwd_nfsroot

$ diff -u /export/nfsroot_{staging,ro}/etc/group
  ( empty )
```