### PR TITLE
netboot: serve kernel/initrd from the rhfs instead of gw

### DIFF
--- a/ansible/playbook-rhfs.yml
+++ b/ansible/playbook-rhfs.yml
@@ -29,6 +29,10 @@
       tags: base
 
     - import_role:
+        name: nginx
+      tags: nginx
+
+    - import_role:
         name: libprologin
       tags: libprologin
 

--- a/ansible/roles/netboot/templates/prologin/netboot.yml
+++ b/ansible/roles/netboot/templates/prologin/netboot.yml
@@ -1,2 +1,2 @@
-static_path: /srv/tftp
 options: root=/dev/nfs ip=${ip}:${next-server}:${gateway}:${netmask}:${hostname}.prolo:eth0:none nosplash rootdelay=0
+fallback: false

--- a/ansible/roles/rfs/tasks/main.yml
+++ b/ansible/roles/rfs/tasks/main.yml
@@ -29,5 +29,11 @@
     state: started
     enabled: True
 
+- name: Install the nginx http boot service
+  template:
+    src: 'nginx/http_boot.nginx'
+    dest: '/etc/nginx/services/'
+  notify: reload nginx
+
 - import_tasks: rfs-system.yml
   when: rhfs_master

--- a/ansible/roles/rfs/templates/nginx/http_boot.nginx
+++ b/ansible/roles/rfs/templates/nginx/http_boot.nginx
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    server_name ~^rh?fs\d+$;
+
+    access_log logs/rhfs_boot.access.log main;
+
+    location /boot {
+        autoindex on;
+        root {{ rfs_ro }};
+    }
+}

--- a/etc/prologin/netboot.yml
+++ b/etc/prologin/netboot.yml
@@ -1,2 +1,2 @@
-static_path: /srv/tftp
+fallback: false
 options: root=/dev/nfs ip=${ip}:${next-server}:${gateway}:${netmask}:${hostname}.prolo:eth0:none nosplash rootdelay=0


### PR DESCRIPTION
This commit adds a nginx server on each RHFS, which serves
/export/nfsroot_ro/boot with an autoindex. Instead of having to scp the
current kernel and initrd on the gw, netboot now redirects the iPXE
client to fetch these directly from the RHFS.

This allows to avoid synchronization issues (when we update the kernel
but forget to scp some files to gw), and ensures that the kernel used
for netbooting is always the exact kernel present in the remote
filesystem we boot from.

![image](https://user-images.githubusercontent.com/4927883/81118200-c6809200-8f28-11ea-8d37-1b8c9466b791.png)