### PR TITLE
ansible: fix inactive users when syncing to wiki

### DIFF
--- a/ansible/roles/wiki/templates/prologin/wiki-udbsync.yml
+++ b/ansible/roles/wiki/templates/prologin/wiki-udbsync.yml
@@ -21,7 +21,7 @@ orga_group: ""
 root_group: ""
 
 # Groups which should be synchronized to Django users
-allowed_groups: ["orga", "root"]
+allowed_groups: ["orga", "root", "user"]
 
 # Groups which can log in to the Django admin
 staff_groups: ["orga", "root"]


### PR DESCRIPTION
Fixes #189 

Hello,

This PR modifies the is_active attributes of the wiki users by adding the "user" group to the allowed_groups.

Thanks.