### PR TITLE
fix matchmaker view

### DIFF
--- a/python-lib/prologin/concours/stechec/views.py
+++ b/python-lib/prologin/concours/stechec/views.py
@@ -318,7 +318,7 @@ class NewMatchView(LoginRequiredMixin, FormView):
             match = models.Match(
                 author=self.request.user,
                 status='new',
-                priority=models.Match.Priority.INTERACTIVE,
+                priority=models.MatchPriority.INTERACTIVE,
             )
             if settings.STECHEC_USE_MAPS:
                 match.map = form.cleaned_data['map']


### PR DESCRIPTION
Fix of a tiny typo that was crashing the view before starting a match:

```
Internal Server Error: /matches/new/
Traceback (most recent call last):
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/views/generic/base.py", line 71, in view
    return self.dispatch(request, *args, **kwargs)
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/contrib/auth/mixins.py", line 52, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/views/generic/base.py", line 97, in dispatch
    return handler(request, *args, **kwargs)
  File "/home/remi/code/prologin/sadm/.venv/lib/python3.8/site-packages/django/views/generic/edit.py", line 142, in post
    return self.form_valid(form)
  File "/home/remi/code/prologin/sadm/python-lib/prologin/concours/stechec/views.py", line 321, in form_valid
    priority=models.Match.Priority.INTERACTIVE,
AttributeError: type object 'Match' has no attribute 'Priority'
[04/Aug/2020 16:58:36] "POST /matches/new/ HTTP/1.1" 500 102998
```