### PR TITLE
presence: send logout notification from pam module

### DIFF
--- a/prologin/presenced/pam_prologin.py
+++ b/prologin/presenced/pam_prologin.py
@@ -216,6 +216,10 @@ def handle_close_session(username: str):
     time.sleep(2)
     umount_home(username)
 
+    # Notify presencesync we're logging out.
+    presencesync_client = prologin.presencesync.client.connect(publish=True)
+    presencesync_client.notify_logout(username, current_hostname())
+
 
 def main():
     # We use stderr for communication with PAM. Don't write on it.

--- a/prologin/presencesync/client.py
+++ b/prologin/presencesync/client.py
@@ -54,6 +54,21 @@ class Client(prologin.synchronisation.Client):
         else:
             return None
 
+    def notify_logout(self, login, hostname):
+        """Tell that `login` is logging out from `hostname` to the PresenceSync
+        server. Return None if this is fine, or some failure reason otherwise.
+        """
+        r = self.send_request(
+            '/logout', self.pub_secret, {'login': login, 'hostname': hostname}
+        )
+        logging.debug(
+            'Notify logout: PresenceSync status code is %s', r.status_code
+        )
+        if r.status_code != 200:
+            return r.text or 'No reason given'
+        else:
+            return None
+
     def send_heartbeat(self, login, hostname):
         """Send a heartbeat to the PresenceSync server in order to keep
         the `login` of the user logged on `hostname`.


### PR DESCRIPTION
Fixes #199.

Tested on the container setup:
```
Aug 15 01:01:10 pas-r01p01 lightdm[1294]: pam_unix(lightdm:session): session closed for user admin
Aug 15 01:01:11 pas-r01p01 pam_prologin[1360]: [DEBUG] pam_prologin invoked for type=close_session, service=lightdm, user=admin
Aug 15 01:01:13 pas-r01p01 pam_prologin[1360]: [INFO] Creating PresenceSync connection object: url=http://presencesync/, publish=True
Aug 15 01:01:13 pas-r01p01 pam_prologin[1360]: [DEBUG] Starting new HTTP connection (1): presencesync:80
Aug 15 01:01:13 pas-r01p01 pam_prologin[1360]: [DEBUG] http://presencesync:80 "POST /logout HTTP/1.1" 200 0
Aug 15 01:01:13 pas-r01p01 pam_prologin[1360]: [DEBUG] Notify logout: PresenceSync status code is 200
Aug 15 01:01:13 pas-r01p01 pam_prologin[1360]: [INFO] Execution of handler for PAM close_session succeeded


Aug 15 01:01:13 gw presencesync[5157]: [INFO] sending update message: [{'type': 'delete', 'data': {'login': 'admin', 'hostname': None}}]
Aug 15 01:01:13 gw presencesync[5157]: [INFO] 200 POST /logout (127.0.0.1) 1.28ms
```

Verified you can log on again <5s after logging out.