### PR TITLE
ansible: add djenius (radio) & mpv roles

### DIFF
--- a/ansible/playbook-misc.yml
+++ b/ansible/playbook-misc.yml
@@ -10,6 +10,7 @@
         hostname: misc
         aliases:
           - irc
+          - radio
           - sgoinfre
         mac: '{{ mac }}'
         mtype: service
@@ -44,6 +45,14 @@
     - import_role:
         name: ircd
       tags: ircd
+
+    - import_role:
+        name: nginx
+      tags: nginx
+
+    - import_role:
+        name: djenius
+      tags: djenius
 
     - import_role:
         name: sgoinfre

--- a/ansible/playbook-rfs-container.yml
+++ b/ansible/playbook-rfs-container.yml
@@ -56,3 +56,7 @@
     - import_role:
         name: sgoinfre_mount
       tags: sgoinfre_mount
+
+    - import_role:
+        name: mpv
+      tags: mpv

--- a/ansible/roles/base/defaults/main.yml
+++ b/ansible/roles/base/defaults/main.yml
@@ -31,6 +31,7 @@ prologin_groups:
   ansible: 20180
   paste: 20190
   wiki: 20200
+  djenius: 20220
 
 prologin_users:
   mdb:
@@ -152,4 +153,9 @@ prologin_users:
     uid: 20200
     groups:
       - wiki
+      - udbsync_public
+  djenius:
+    uid: 20220
+    groups:
+      - djenius
       - udbsync_public

--- a/ansible/roles/djenius/.gitignore
+++ b/ansible/roles/djenius/.gitignore
@@ -1,0 +1,1 @@
+files/despotify/

--- a/ansible/roles/djenius/defaults/main.yml
+++ b/ansible/roles/djenius/defaults/main.yml
@@ -1,0 +1,2 @@
+djenius_venv_dir: "/opt/prologin/djenius_venv"
+despotify_port: 20222

--- a/ansible/roles/djenius/handlers/main.yml
+++ b/ansible/roles/djenius/handlers/main.yml
@@ -1,0 +1,14 @@
+- name: restart djenius
+  systemd:
+    name: 'djenius-{{ item }}'
+    state: restarted
+    daemon_reload: True
+  with_items:
+    - resolver
+    - server
+
+- name: restart despotify
+  systemd:
+    name: 'despotify'
+    state: restarted
+    daemon_reload: True

--- a/ansible/roles/djenius/tasks/main.yml
+++ b/ansible/roles/djenius/tasks/main.yml
@@ -1,0 +1,92 @@
+- name: Install libprologin requirements
+  pip:
+    requirements: "{{ sadm_path }}/requirements.txt"
+    virtualenv: "{{ djenius_venv_dir }}"
+    virtualenv_command: python3 -m venv
+
+- name: Install djenius Python packages
+  pip:
+    name:
+      - "{{ sadm_path }}"
+      - djenius-auth-udbsync~=1.0
+      - djenius~=1.0
+      - youtube_dl
+    virtualenv: "{{ djenius_venv_dir }}"
+    virtualenv_command: python3 -m venv
+
+- name: Symlink youtube-dl
+  file:
+    path: /usr/bin/youtube-dl
+    state: link
+    src: "{{ djenius_venv_dir }}/bin/youtube-dl"
+
+- name: Create djenius state directory
+  file:
+    path: "/opt/prologin/djenius"
+    owner: djenius
+    group: djenius
+    state: directory
+    mode: '0755'
+
+- name: Install djenius nginx config
+  template:
+    src: 'nginx/djenius.nginx'
+    dest: '/etc/nginx/services/'
+    mode: 0644
+  notify: reload nginx
+
+- name: Install djenius systemd services
+  template:
+    src: 'systemd/djenius-{{ item }}.service'
+    dest: '/etc/systemd/system/'
+    mode: 0644
+  with_items:
+    - server
+    - resolver
+  notify: restart djenius
+
+- name: Enable djenius-resolver
+  systemd:
+    name: djenius-resolver
+    enabled: True
+
+- name: Enable and start djenius-server
+  systemd:
+    name: djenius-server
+    enabled: True
+    state: started
+
+- name: Check whether despotify is available
+  tags: despotify
+  local_action: stat path={{ role_path }}/files/despotify/
+  register: despotify
+
+- name: Install despotify binaries/config
+  tags: despotify
+  when: despotify.stat.exists and item.state == 'file'
+  copy:
+    src: "{{ item.src }}"
+    dest: "/opt/prologin/djenius/{{ item.path }}"
+    mode: preserve
+    owner: djenius
+    group: djenius
+  with_filetree: despotify/
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Install despotify service
+  tags: despotify
+  when: despotify.stat.exists
+  template:
+    src: 'systemd/despotify.service'
+    dest: '/etc/systemd/system/'
+    mode: 0644
+  notify: restart despotify
+
+- name: Enable despotify service
+  tags: despotify
+  when: despotify.stat.exists
+  systemd:
+    name: despotify
+    enabled: True
+    state: started

--- a/ansible/roles/djenius/templates/nginx/djenius.nginx
+++ b/ansible/roles/djenius/templates/nginx/djenius.nginx
@@ -1,0 +1,76 @@
+proxy_cache_path /opt/prologin/djenius/nginxcache
+    levels=1:2                # Shard files into prefix directories.
+    keys_zone=cache_zone:30m  # Keep 30MB worth of key space, that's plenty.
+    max_size=10g              # Max cache size; it's audio, make it large.
+    inactive=30d              # Duration after which content is stale; song
+                              # blobs shouldn't ever change, neither should
+                              # search results on such a small time frame.
+    use_temp_path=off;
+
+upstream resolver_backend {
+    # Server resolving search results, cover art images and song audio from
+    # the various resolvers (YouTube, Spotify).
+    # Responses are cached using the cache conf above.
+    server unix:/opt/prologin/djenius/resolver.socket;
+}
+
+upstream server_backend {
+    # Server for the API (Websockets).
+    server unix:/opt/prologin/djenius/server.socket;
+}
+
+server {
+    listen 80;
+    server_name radio;
+    include sso/handler;
+
+    access_log logs/djenius.access.log main;
+
+    location /status {
+        stub_status on;
+        access_log off;
+    }
+
+    location /resolve {
+        proxy_pass http://resolver_backend;
+        # Strip the /resolve prefix.
+        rewrite /resolve/(.*) /$1 break;
+        # Cache responses.
+        proxy_cache cache_zone;
+        proxy_cache_key $uri$is_args$args;
+        # Add some debug header.
+        add_header X-Proxy-Cache $upstream_cache_status;
+        add_header X-Proxy-Key $uri$is_args$args;
+        # Don't allow concurrent requests on the same content (queue-like).
+        proxy_cache_lock on;
+        # We really don't want anything to bypass the cache.
+        proxy_cache_lock_age 10m;
+        proxy_cache_lock_timeout 1h;
+        # That should be more than enough for < 8 minute songs.
+        proxy_read_timeout 5m;
+        # OK responses can be cached for super long.
+        proxy_cache_valid 200 30d;
+        # Error responses are cached for just a few seconds.
+        proxy_cache_valid any 10s;
+        # Serve stale content if the backend is down (ie. does not reply
+        # within 5s, which is not the same as the *read* timeout, that can
+        # take multiple minutes for Spotify).
+        proxy_cache_use_stale timeout;
+        proxy_connect_timeout 5s;
+    }
+
+    location /ws {
+        include sso/protect;
+
+        # Websockets stuff.
+        proxy_pass http://server_backend;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+    }
+
+    location / {
+        # Try frontend static files first, fallback to the frontend API.
+        root /opt/prologin/djenius_venv/djenius/www;
+        try_files $uri $uri/;
+    }
+}

--- a/ansible/roles/djenius/templates/systemd/despotify.service
+++ b/ansible/roles/djenius/templates/systemd/despotify.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=despotify
+After=network-online.target
+
+[Service]
+Type=simple
+User=djenius
+WorkingDirectory=/opt/prologin/djenius
+EnvironmentFile=/opt/prologin/djenius/despotify.env
+Environment=DESPOTIFY_COMPANION=/opt/prologin/djenius/despotify-companion
+Environment=DESPOTIFY_CDM=/opt/prologin/djenius/libwidevinecdm.so
+Environment=GOPS_CONFIG_DIR=/opt/prologin/djenius
+ExecStart=/opt/prologin/djenius/despotify --listen 127.0.0.1:{{ despotify_port }}
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/djenius/templates/systemd/djenius-resolver.service
+++ b/ansible/roles/djenius/templates/systemd/djenius-resolver.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=djenius (collaborative jukebox) resolver
+After=network-online.target
+
+[Service]
+Type=simple
+User=djenius
+WorkingDirectory=/opt/prologin/djenius
+Environment=DESPOTIFY_URL=http://127.0.0.1:{{ despotify_port }}
+ExecStart={{ djenius_venv_dir }}/bin/python -m djenius.bin.resolver \
+    --logging=INFO \
+    --unix=/opt/prologin/djenius/resolver.socket
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/djenius/templates/systemd/djenius-server.service
+++ b/ansible/roles/djenius/templates/systemd/djenius-server.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=djenius (collaborative jukebox) server
+After=network-online.target
+Requires=djenius-resolver.service
+
+[Service]
+Type=simple
+User=djenius
+WorkingDirectory=/opt/prologin/djenius
+ExecStart={{ djenius_venv_dir }}/bin/python -m djenius.bin.backend \
+    --logging=INFO \
+    --unix=/opt/prologin/djenius/server.socket \
+    --state-file=/opt/prologin/djenius/state.pickle \
+    --whoosh-dir=/opt/prologin/djenius/whoosh \
+    --auth=djenius_auth_udbsync.UdbSyncAuthProvider \
+    --resolver=http://radio/resolve \
+    --mpv=speaker:20221
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/mpv/tasks/main.yml
+++ b/ansible/roles/mpv/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Install socat & mpv
+  pacman:
+    name:
+      - mpv
+      - socat
+
+- name: Install mpv and mpv-tcp-bridge systemd services
+  template:
+    src: 'systemd/{{ item }}.service'
+    dest: '/usr/lib/systemd/user/'
+    mode: 0644
+  with_items:
+    - mpv
+    - mpv-tcp-bridge

--- a/ansible/roles/mpv/templates/systemd/mpv-tcp-bridge.service
+++ b/ansible/roles/mpv/templates/systemd/mpv-tcp-bridge.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=mpv TCP bridge using socat
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/socat TCP-LISTEN:20221,reuseaddr,pf=ip4,fork UNIX-CONNECT:/tmp/mpv.sock
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/mpv/templates/systemd/mpv.service
+++ b/ansible/roles/mpv/templates/systemd/mpv.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=mpv
+After=network-online.target
+After=mpv-tcp-bridge.service
+Requires=mpv-tcp-bridge.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/mpv --input-ipc-server=/tmp/mpv.sock \
+    --idle --input-terminal=no --no-ytdl --no-audio-display --force-seekable=yes
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* Add a `djenius` role on `misc` that installs djenius as bunch of pypi-published packages
* Add 2 systemd services core to djenius (server & resolver)
* Add optional ansible tasks to deploy `despotify` when available
* Add an `mpv` role on `rfs-container` that creates an mpv (and companion bridge) systemd user-service, so one of the machines can act as the radio soundcard; requires manual startup though

Tested on container infra. SSO & djenius-auth-udbsync work. The interface works. I was able to hear the music (mpv) in a contestant libvirt VM! :notes:

![image](https://user-images.githubusercontent.com/81353/90324633-75ddf380-df71-11ea-8604-fa0d981a7df1.png)