### PR TITLE
Refactor master/worker operations and error reporting

### DIFF
--- a/ansible/playbook-gw.yml
+++ b/ansible/playbook-gw.yml
@@ -119,6 +119,12 @@
         port: 80
         timeout: 180
 
+    - name: Wait for external internet to become available
+      wait_for:
+        host: www.gstatic.com
+        port: 80
+        timeout: 180
+
     - import_role:
         name: netboot
       tags: netboot

--- a/ansible/roles/concours/templates/django/manage.py
+++ b/ansible/roles/concours/templates/django/manage.py
@@ -5,7 +5,7 @@ import sys
 if __name__ == "__main__":
     settings_module = (
         "prologin.concours.settings_test"
-        if sys.argv[1] == "test"
+        if len(sys.argv) >= 2 and sys.argv[1] == "test"
         else "prologin.concours.settings"
     )
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", settings_module)

--- a/ansible/roles/libprologin/tasks/main.yml
+++ b/ansible/roles/libprologin/tasks/main.yml
@@ -36,6 +36,7 @@
     name: "{{ sadm_path }}"
     virtualenv: "{{ venv_dir }}"
     virtualenv_command: python3 -m venv
+  tags: libprologin_setup
 
 - name: create prologin configuration directory
   file:

--- a/ansible/roles/workernode/templates/prologin/workernode.yml
+++ b/ansible/roles/workernode/templates/prologin/workernode.yml
@@ -3,8 +3,6 @@ master:
     host: masternode
     port: 8067
     heartbeat_secs: 5             # Must be < to the master timeout.
-    max_retries: 15               # Max retries when the master is down
-    retry_delay: 10               # Delay between each retry
     shared_secret: "{{ masternode_secret }}"
 
 # Configuration of this worker.

--- a/debugconfig/workernode.yml
+++ b/debugconfig/workernode.yml
@@ -3,8 +3,6 @@ master:
     host: masternode
     port: 8067
     heartbeat_secs: 5             # Must be < to the master timeout.
-    max_retries: 15               # Max retries when the master is down
-    retry_delay: 10               # Delay between each retry
     shared_secret: "%%SECRET:cluster%%"
 
 # Configuration of this worker.

--- a/prologin/concours/stechec/management/commands/restart_failed.py
+++ b/prologin/concours/stechec/management/commands/restart_failed.py
@@ -1,0 +1,11 @@
+from django.core.management.base import BaseCommand
+
+from prologin.concours.stechec.models import Match, Champion
+
+
+class Command(BaseCommand):
+    help = "Restart failed masternode tasks"
+
+    def handle(self, *args, **options):
+        Champion.objects.filter(status='failed').update(status='new')
+        Match.objects.filter(status='failed').update(status='new')

--- a/prologin/concours/stechec/static/css/main.css
+++ b/prologin/concours/stechec/static/css/main.css
@@ -108,7 +108,8 @@ i.champ-status {
   animation-iteration-count: infinite;
 }
 
-
 .codehilite > pre {
   white-space: pre-wrap;
+  background: rgba(0,0,0,0.02);
+  border-color: #111;
 }

--- a/prologin/concours/stechec/templates/stechec/champion-detail.html
+++ b/prologin/concours/stechec/templates/stechec/champion-detail.html
@@ -1,10 +1,15 @@
 {% extends "stechec/base.html" %}
 {% load static %}
 {% load django_bootstrap_breadcrumbs %}
+{% load pygmentize %}
 
 {% block title %}{{ champion.name }} – Champion{% endblock %}
 {% block titleh1 %}Détails du champion {{ champion.name }}
   <small>#{{ champion.id }}</small>{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{% static 'css/pygments-monokai.css' %}" type="text/css">
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ block.super }}
@@ -54,13 +59,22 @@
     </div>
   </div>
 
-  {% if champion.compilation_log and can_see_log %}
+  {% if can_see_log %}
     <p>
-      <button class="btn btn-default btn-small" data-role="toggler" data-target="#log"><i class="fa"></i>
-        <span>Afficher</span> le log de
-        compilation
-      </button>
-    <pre id="log">{{ champion.compilation_log }}</pre>
+    <details>
+      <summary>Log de compilation</summary>
+      <pre>{{ champion.compilation_log }}</pre>
+    </details>
+    </p>
+  {% endif %}
+
+  {% if request.user.is_staff %}
+    <p>
+    <details>
+      <summary>Résultat workernode</summary>
+      {% pygmentize champion.workernode_result_printable 'python' %}
+    </details>
+    </p>
   {% endif %}
 
 {% endblock %}

--- a/prologin/concours/stechec/templates/stechec/match-detail.html
+++ b/prologin/concours/stechec/templates/stechec/match-detail.html
@@ -1,9 +1,14 @@
 {% extends "stechec/base.html" %}
 {% load humanize static substract %}
 {% load django_bootstrap_breadcrumbs %}
+{% load pygmentize %}
 
 {% block title %}Détail du match{% endblock %}
 {% block titleh1 %}Détail du match <small>#{{ match.id }}</small>{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="{% static 'css/pygments-monokai.css' %}" type="text/css">
+{% endblock %}
 
 {% block breadcrumbs %}
   {{ block.super }}
@@ -101,11 +106,26 @@
   </table>
 
   <p>
-  <button class="btn btn-default" data-role="toggler" data-target="#serv-log"><i class="fa"></i>
-      <span>Afficher</span> le log serveur
-  </button>
+  <details>
+    <summary>Log server (sortie standard)</summary>
+    <pre>{{ match.log_out }}</pre>
+  </details>
   </p>
-  <pre id="serv-log">{{ match.log }}</pre>
+  <p>
+  <details>
+    <summary>Log server (sortie d'erreur)</summary>
+    <pre>{{ match.log_err }}</pre>
+  </details>
+  </p>
+
+  {% if request.user.is_staff %}
+    <p>
+    <details>
+      <summary>Résultat workernode</summary>
+      {% pygmentize match.workernode_result_printable 'python' %}
+    </details>
+    </p>
+  {% endif %}
 
   {% if settings.STECHEC_REPLAY %}
     <h2>Replay</h2>

--- a/prologin/concours/stechec/templates/stechec/stub_status_champion.html
+++ b/prologin/concours/stechec/templates/stechec/stub_status_champion.html
@@ -6,5 +6,7 @@
 <i class="champ-status fa fa-check i-align"></i>
 {% elif champion.status == 'error' %}
 <i class="champ-status fa fa-times i-align"></i>
+{% elif champion.status == 'failed' %}
+<i class="champ-status fa fa-exclamation-circle i-align"></i>
 {% endif %}
 {{ champion.get_status_display }}

--- a/prologin/concours/stechec/templates/stechec/stub_status_match.html
+++ b/prologin/concours/stechec/templates/stechec/stub_status_match.html
@@ -6,5 +6,7 @@
 <i class="champ-status fa fa-cogs i-align"></i>
 {% elif match.status == 'done' %}
 <i class="champ-status fa fa-check i-align"></i>
+{% elif match.status == 'failed' %}
+<i class="champ-status fa fa-exclamation-circle i-align"></i>
 {% endif %}
 {{ match.get_status_display }}

--- a/prologin/masternode/task.py
+++ b/prologin/masternode/task.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 # This file is part of Prologin-SADM.
 #
-# Copyright (c) 2014-2015 Antoine Pietri <antoine.pietri@prologin.org>
+# Copyright (c) 2014-2020 Antoine Pietri <antoine.pietri@prologin.org>
 # Copyright (c) 2011 Pierre Bourdon <pierre.bourdon@prologin.org>
 # Copyright (c) 2011 Association Prologin <info@prologin.org>
 #
@@ -27,7 +27,7 @@ from base64 import b64encode
 from pathlib import Path
 
 
-def get_champion_path(config, user, cid):
+def get_champion_dir(config, user: str, cid: int) -> Path:
     return Path(
         config['contest']['directory'],
         config['contest']['game'],
@@ -37,7 +37,7 @@ def get_champion_path(config, user, cid):
     )
 
 
-def get_match_path(config, match_id):
+def get_match_dir(config, match_id: int) -> Path:
     match_id_high = "{:03}".format(match_id // 1000)
     match_id_low = "{:03}".format(match_id % 1000)
     return Path(
@@ -91,7 +91,7 @@ class CompilationTask(Task):
         self.db = db
         self.user = user
         self.champ_id = champ_id
-        self.champ_path = get_champion_path(config, user, champ_id)
+        self.champ_path = get_champion_dir(config, user, champ_id)
 
     @property
     def slots_taken(self):
@@ -134,12 +134,12 @@ class MatchTask(Task):
         self.mid = mid
         self.map_contents = map_contents
         self.players = {}
-        self.match_path = get_match_path(config, self.mid)
+        self.match_path = get_match_dir(config, self.mid)
 
         for (cid, mpid, user) in players:
             ctgz = b64encode(
                 (
-                    get_champion_path(config, user, cid)
+                    get_champion_dir(config, user, cid)
                     / 'champion-compiled.tgz'
                 ).read_bytes()
             ).decode()

--- a/prologin/tests/workernode_operations_test.py
+++ b/prologin/tests/workernode_operations_test.py
@@ -284,7 +284,8 @@ class FakeMatchTest(unittest.TestCase):
                 msg='\nClient script output:\n' + player_result['stdout'],
             )
             self.assertIn('some log on stdout', player_result['stdout'])
-            self.assertIn('some log on stderr', player_result['stderr'])
+            # stderr is merged in stdout
+            self.assertIn('some log on stderr', player_result['stdout'])
             self.assertIn('map: TEST_MAP', player_result['stdout'])
             self.assertIn(f'name: {player_id}', player_result['stdout'])
             self.assertIn(f'client_id: {order_id}', player_result['stdout'])

--- a/prologin/workernode/compile-champion.sh
+++ b/prologin/workernode/compile-champion.sh
@@ -28,7 +28,6 @@ champion_dir=$2
 
 compil_dir=`mktemp -d /tmp/stechec_compil_XXXXXX`
 champion_tarball=$champion_dir/champion.tgz
-compil_log=$champion_dir/compilation.log
 lang_file=_lang
 
 # Signal the makefiles to use wildcards to find the champion sources
@@ -89,7 +88,7 @@ export STECHEC_SERVER=1
 
     rm -rf "$champion_dir/champion-compiled/"
     echo 'Success!'
-) 2>&1 | tee "$compil_log"
+) 2>&1
 
 res=${PIPESTATUS[0]}
 rm -rf "$compil_dir"

--- a/prologin/workernode/worker.py
+++ b/prologin/workernode/worker.py
@@ -1,6 +1,6 @@
 # This file is part of Prologin-SADM.
 #
-# Copyright (c) 2013-2015 Antoine Pietri <antoine.pietri@prologin.org>
+# Copyright (c) 2013-2020 Antoine Pietri <antoine.pietri@prologin.org>
 # Copyright (c) 2011 Pierre Bourdon <pierre.bourdon@prologin.org>
 # Copyright (c) 2011-2014 Association Prologin <info@prologin.org>
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,11 +16,14 @@ prometheus_client==0.6.0
 psycopg2-binary==2.8.2
 py-postgresql==1.2.1
 Pygments==2.3.1
-pytest==4.4.1
+pytest==5.4.0
+pytest-asyncio==0.14.0
+pytest-aiohttp==0.3.0
 PyYAML==5.1
 requests==2.21.0
 tornado==4.5.1
 wiki==0.5
+tenacity==5.1.4
 
 # From prologin
 -e git://github.com/prologin/camisole.git#egg=camisole


### PR DESCRIPTION
This commit is a big refactor that spans the entire master/worker stack.

The workernode operation code has always been a mess of tons of
parameters sent in a spaghetti code way. Error handling was also a mess,
and we had to keep adding new failure modes every time we encountered a
new problem. Outputs were mixed up together along with the isolate
output, which led to hacks of trying to shove error logs in as few
variables as possible.

Another big issue which was entangled with the previous one is that of
error reporting. Since we had no consistent way of noticing errors in a
clean homogeneous way between the different operations, we never
actually notified masternode that tasks failed. We partially updated the
remote state with error logs, but the tasks were left in pending mode
and restarted for no reason, or worse, marked as completed even if they
failed.

We also had no way of knowing what happened easily when a match was
stuck in pending mode and had to browse the worker logs manually in the
remote machines, which was less than convenient. Although this is
sometimes unavoidable when the error reporting code itself crashes, it
certainly should not be the default behavior for all kinds of faults.

This commit aims at addressing all these issues. It does this a number
of ways:

- First, I updated camisole so that internal isolate errors raise an
  exception. When isolate's return code is >= 2, it means the sandbox
  itself has crashed. This can happen for a number of ways that are
  pretty common when workernode is misconfigured: execve failing because
  of a missing executable, executable with incorrect permissions, not
  enough memory in the cgroup to start the sandbox, ...

  Having this being reported as an exception as early as possible saves
  a lot of trouble later in the chain, where we had a lot of code
  handling errors that were just side effects of this issue -- e.g
  PermissionErrors for files that were supposed to be written in the
  sandbox, as the sandbox does not clean up its permissions in case of a
  crash.

  Commit here:
  https://github.com/prologin/camisole/commit/898cce02ac9cf858e1ca160ecaadbbecf4323a7f

- Then, I completely rewrote operations.py using classes to refactor
  common behavior between operations. This allowed me to wrap all the
  isolation operations inside a common entry point that does multiple
  things:

  1. I create a result dictionary at the very beginning that is always
     the return value, whatever happens during the execution. When the
     operation is running, this result dict is filled with information
     and metadata, like the isolate stderr/stdout, the stdout/stderr of
     the process, and the exit codes.
     This ensures that whatever code path is taken, I am able to report
     as many information as possible in the end.

  2. Everything is wrapped in a try/except block, so that if anything
     happens I just edit the output dictionary to add the traceback and
     error message.. This also means I was able to simplify a lot of
     error handling code that used to manually add all the error
     logs to their return values.

  As an added bonus, all the operation functions now only return this
  result dictionary, which makes adding result information more flexible
  and avoids having to unpack giant tuples at each function call.

- I rewrote the workernode_operations_test.py file to match the new
  result dictionary, and added a few missing tests.

- I refactored workernode/worker.py to use caller-side retry logic to
  send the results to masternode using the tenacity retrying library.

- In masternode, I also had to change the code to match the new result
  format, but I didn't stop there. Since the error information is now
  properly reported in the result dictionary instead of being discarded
  down in the chain, I can now set the match and compilation status as
  *failed* when an internal server error occurred, to avoid retrying
  them indefinitely for no reason. I also write a new file
  workernode-result.json for each type of task, that contains the
  *entire result dictionary*, to ease debugging of failed matches.

- I did visual changes to concours to match the new behavior:

    1. There is a new font-awesome error icon for failed tasks.
    2. Server logs are now separated in stdout and stderr.
    3. Staff users can see a new "Workernode result" section which
       contains the result dict of the task, pretty-printed. The dict is
       recursively edited to truncate long strings (like base64 dumps).

- I added a new manage.py restart_failed command, which... restarts the
  failed tasks. The idea is that failed tasks should only become failed
  because of internal server errors. Once these bugs are fixed, we
  should be able to restart the failed tasks using this command.